### PR TITLE
Fixes divide by zero exception when w.ratio = 0

### DIFF
--- a/win/win.go
+++ b/win/win.go
@@ -80,7 +80,7 @@ func New(opts ...Option) (*Win, error) {
 		// hiDPI hack
 		width, _ := w.w.GetFramebufferSize()
 		w.ratio = width / o.width
-		if w.ratio != 1 {
+		if w.ratio != 1 && w.ratio != 0 {
 			o.width /= w.ratio
 			o.height /= w.ratio
 		}


### PR DESCRIPTION
I have no idea what the code does, this might fuck shit up, but I edited my local copy of the file with these changes and it fixed a divide by zero issue I would get randomly.