### PR TITLE
Removed key validation in SetKeyCallback()

### DIFF
--- a/win/win.go
+++ b/win/win.go
@@ -234,11 +234,13 @@ func (w *Win) eventThread() {
 		w.eventsIn <- KbType{r}
 	})
 
-	w.w.SetKeyCallback(func(_ *glfw.Window, key glfw.Key, _ int, action glfw.Action, _ glfw.ModifierKey) {
+	w.w.SetKeyCallback(func(_ *glfw.Window, key glfw.Key, _ int, action glfw.Action, _ glfw.ModifierKey) {		
+		/* Just let all keys through? Why do we validate this here? It prevents most keys from becoming events
 		k, ok := keys[key]
 		if !ok {
 			return
 		}
+		*/
 		switch action {
 		case glfw.Press:
 			w.eventsIn <- KbDown{k}


### PR DESCRIPTION
If a key is not specified in the key map it will not be passed as an event.  This prevents things like text entry... I have disabled the validation and just let all keys be registered as events.